### PR TITLE
Fix for KeyError when not able to get description.

### DIFF
--- a/snnow.py
+++ b/snnow.py
@@ -169,10 +169,16 @@ class SportsnetNow:
                 except:
                     title = curr_item.attributes['e']
                 episode = curr_item.attributes['e']
-                description = curr_item.attributes['ed']
+                
+                try:
+                    description = curr_item.attibutes['ed']
+                    show['plot'] = description.value.encode('utf-8').strip().decode('utf-8')
+                except:
+                    show['plot'] = 'No description found'
+                
                 show['tvshowtitle'] = title.value.encode('utf-8').strip().decode('utf-8')
                 show['title'] = episode.value.encode('utf-8').strip().decode('utf-8')
-                show['plot'] = description.value.encode('utf-8').strip().decode('utf-8')
+                
                 guide[cid] = show
 
         return guide


### PR DESCRIPTION
A quick fix for when unable to find 'ed' attribute

kodi.log:

```
13:20:00 T:11424   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.KeyError'>
                                            Error Contents: ('ed',)
                                            Traceback (most recent call last):
                                              File "C:\Users\Mike\AppData\Roaming\Kodi\addons\plugin.video.snnow\default.py", line 142, in <module>
                                                createMainMenu()
                                              File "C:\Users\Mike\AppData\Roaming\Kodi\addons\plugin.video.snnow\default.py", line 50, in createMainMenu
                                                guide = sn.getGuideData()
                                              File "C:\Users\Mike\AppData\Roaming\Kodi\addons\plugin.video.snnow\snnow.py", line 172, in getGuideData
                                                description = curr_item.attributes['ed']
                                              File "C:\Program Files (x86)\Kodi\system\python\Lib\xml\dom\minidom.py", line 522, in __getitem__
                                                return self._attrs[attname_or_tuple]
                                            KeyError: ('ed',)
                                            -->End of Python script error report<--
```
