### PR TITLE
Update cogeco.py

### DIFF
--- a/cogeco.py
+++ b/cogeco.py
@@ -40,7 +40,7 @@ class Cogeco:
         html = resp.read()
 
         # TODO: this could be made a function to to parse and return the value based on an expression
-        action = re.search('<form.*?action=\"(.*?)"', html, re.MULTILINE)
+        action = re.search('<form.*?action=\"(.*?)\"', html, re.MULTILINE)
         if not action:
             print "Unable to find action form"
             return None
@@ -81,7 +81,7 @@ class Cogeco:
 
         html = resp.read()
 
-        action = re.search('<form.*?action=\"(.*?)"', html, re.MULTILINE)
+        action = re.search('<form.*?action=\"(.*?)\"', html, re.MULTILINE)
         if not action:
             print "Unable to find action form"
             return None
@@ -109,7 +109,7 @@ class Cogeco:
 
         html = resp.read()
 
-        action = re.search('<form.*?action=\"(.*?)"', html, re.MULTILINE)
+        action = re.search('<form.*?action=\"(.*?)\"', html, re.MULTILINE)
         if not action:
             print "Unable to find action form"
             return None


### PR DESCRIPTION
Fixing REGEX's on lines 43, 84 and 112 to properly escape double-quotes. This change fixes login errors when the add-on runs on certain Python flavours like the one provided in RPi/OpenELEC 7.0.1.